### PR TITLE
Typo in title.skin

### DIFF
--- a/title.skin
+++ b/title.skin
@@ -21,7 +21,7 @@ text=AtomicHiDPI Terminal
 [Background]
 back_image=/title/back.png
 left_corner=/title/left.png
-right_corner=/title/right.pngs
+right_corner=/title/right.png
 
 [FocusButton]
 x=158


### PR DESCRIPTION
The PNG file name of "right_corner" with an extra "s" is removed.